### PR TITLE
一覧表示の実装

### DIFF
--- a/app/assets/stylesheets/items/index.scss
+++ b/app/assets/stylesheets/items/index.scss
@@ -261,6 +261,10 @@ a {
 }
 
 .sold-out {
+  display: none;
+}
+
+.sold-out [data-checked="true"] {
   position: absolute;
   top: 40%;
   width: 100%;

--- a/app/assets/stylesheets/items/index.scss
+++ b/app/assets/stylesheets/items/index.scss
@@ -261,16 +261,13 @@ a {
 }
 
 .sold-out {
-  display: none;
-}
-
-.sold-out [data-checked="true"] {
   position: absolute;
   top: 40%;
   width: 100%;
   text-align: center;
   background-color: crimson;
   transform: skewY(-10deg);
+  display: none;
 }
 
 .sold-out>span {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   def index
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,7 +8,6 @@ require("@rails/activestorage").start()
 require("channels")
 require("../price");
 
-
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
 // or the `imagePath` JavaScript helper below.

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,11 +126,11 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to model: @item, url: items_path, method: :get, local: true do |f| %>
+        <% @items.each do |item| %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,10 +141,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -152,15 +152,14 @@
           </div>
         </div>
         <% end %>
+        <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% unless @items.present? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
+        <div class='item-info' id="dummy">
           <h3 class='item-name'>
             商品を出品してね！
           </h3>
@@ -174,8 +173,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -6,9 +6,7 @@
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, url: items_path, local: true do |f| %>
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
     <div class="img-upload">


### PR DESCRIPTION
# what
viewファイルで表示の分岐と
とitems_controllerにindexアクションの追加

# why
商品一覧機能の実装のため。

Sold outの文字は、CSSはで一時的な見た目のために表示させてません。
商品購入機能の実装時に変更予定

商品を出品してないとサンプルが表示される↓
https://gyazo.com/8cb79c118061b9d37a798f43dd3bc62d
商品が出品されているとサンプルは表示されない↓
https://gyazo.com/d44700e27e136d8a52c6954435146f76
新しい商品から順番に表示される↓
https://gyazo.com/15009e921fe2c718135e7b15b374f281